### PR TITLE
Extend splunk modules to allow cluster role configuration

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,6 +1,6 @@
 name    'puppetlabs-splunk'
-version '3.0.1'
-source  'https://github.com/puppetlabs/puppetlabs-splunk.git'
+version '3.0.1-1'
+source  'https://github.com/hyclak/puppetlabs-splunk.git'
 author  'Puppet Labs'
 license 'Apache License, Version 2.0'
 summary 'Manage and deploy Splunk servers and forwarders'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,14 +40,22 @@
 # Requires: nothing
 #
 class splunk (
-  $package_source = $splunk::params::server_pkg_src,
-  $package_name   = $splunk::params::server_pkg_name,
-  $logging_port   = $splunk::params::logging_port,
-  $splunkd_port   = $splunk::params::splunkd_port,
-  $splunkd_listen = '127.0.0.1',
-  $web_port       = '8000',
-  $purge_inputs   = false,
-  $purge_outputs  = false,
+  $package_source     = $splunk::params::server_pkg_src,
+  $package_name       = $splunk::params::server_pkg_name,
+  $logging_port       = $splunk::params::logging_port,
+  $splunkd_port       = $splunk::params::splunkd_port,
+  $version            = $splunk::params::version,
+  $build              = $splunk::params::build,
+  $src_root           = $splunk::params::src_root,
+  $master_uri         = $splunk::params::master_uri,
+  $replication_port   = $splunk::params::replication_port,
+  $replication_factor = $splunk::params::replication_factor,
+  $search_factor      = $splunk::params::search_factor,
+  $pass4SymmKey       = $splunk::params::pass4SymmKey,
+  $splunkd_listen     = '127.0.0.1',
+  $web_port           = '8000',
+  $purge_inputs       = false,
+  $purge_outputs      = false,
 ) inherits splunk::params {
   include staging
 

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -1,0 +1,35 @@
+class splunk::master 
+{
+  include splunk
+
+  ini_setting {
+    "splunk_master_node":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'mode',
+      value   => 'master',
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+    "splunk_replication_factor":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'replication_factor',
+      value   => "$splunk::replication_factor",
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+    "splunk_search_factor":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'search_factor',
+      value   => "$splunk::search_factor",
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+    "splunk_pass4SymmKey":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'pass4SymmKey',
+      value   => "$splunk::pass4SymmKey",
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -67,11 +67,16 @@
 # Requires: nothing
 #
 class splunk::params (
-  $version      = '5.0.5',
-  $build        = '179365',
-  $src_root     = "puppet:///modules/splunk",
-  $splunkd_port = '8089',
-  $logging_port = '9997',
+  $version            = '6.0.2',
+  $build              = '196940',
+  $src_root           = "puppet:///modules/splunk",
+  $splunkd_port       = '8089',
+  $logging_port       = '9997',
+  $master_uri         = "https://splunk:$splunkd_port",
+  $replication_port   = '9887',
+  $replication_factor = '1',
+  $search_factor      = '1',
+  $pass4SymmKey       = 'splunk',
 ) {
 
   # Based on the small number of inputs above, we can construct sane defaults

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -1,0 +1,41 @@
+class splunk::peer 
+{
+  include splunk
+
+  ini_setting { 
+    "splunk_peer_node":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'mode',
+      value   => 'slave',
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+    "splunk_master_uri":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'master_uri',
+      value   => "$splunk::master_uri",
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+    "splunk_pass4SymmKey":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'pass4SymmKey',
+      value   => "$splunk::pass4SymmKey",
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+  }
+
+  # This is disgusting, but since it could change I don't see how to use 
+  # ini_setting. Other option would be to manage the entire file?
+  exec {
+    "add_replication_port":
+      command => "/bin/echo [replication_port://$splunk::replication_port] >> ${splunk::params::server_confdir}/server.conf",
+      unless => "/bin/grep \"\\[replication_port://$splunk::replication_port\\]\" ${splunk::params::server_confdir}/server.conf";
+    "update_replication_port":
+      command => "/bin/sed -i \"s#\\[replication_port://\\([0-9]\\+\\)\\]#[replication_port://$splunk::replication_port]#g\" ${splunk::params::server_confdir}/server.conf",
+      unless => "/bin/grep \"\\[replication_port://$splunk::replication_port\\]\" ${splunk::params::server_confdir}/server.conf",
+      before => Exec['add_replication_port'];
+}
+
+}

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -35,6 +35,7 @@ class splunk::peer
     "update_replication_port":
       command => "/bin/sed -i \"s#\\[replication_port://\\([0-9]\\+\\)\\]#[replication_port://$splunk::replication_port]#g\" ${splunk::params::server_confdir}/server.conf",
       unless => "/bin/grep \"\\[replication_port://$splunk::replication_port\\]\" ${splunk::params::server_confdir}/server.conf",
+      require => Package[$splunk::package_name],
       before => Exec['add_replication_port'];
 }
 

--- a/manifests/searchhead.pp
+++ b/manifests/searchhead.pp
@@ -1,0 +1,28 @@
+class splunk::searchhead 
+{
+  include splunk
+
+  ini_setting { 
+    "splunk_peer_node":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'mode',
+      value   => 'searchhead',
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+    "splunk_master_uri":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'master_uri',
+      value   => "$splunk::master_uri",
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+    "splunk_pass4SymmKey":
+      path    => "${splunk::params::server_confdir}/server.conf",
+      section => 'clustering',
+      setting => 'pass4SymmKey',
+      value   => "$splunk::pass4SymmKey",
+      require => Package[$splunk::package_name],
+      notify  => Service[$splunk::virtual_service];
+  }
+}


### PR DESCRIPTION
Please forgive me if these changes are the wrong direction in terms of best practices, etc. I was unable to find how to do exactly what I wanted. As things stand now, both the splunk and splunk::foo classes need to be included in a node definition for the role to be properly configured. It's been a while since I've touched Puppet, so I am most definitely rusty.

This request exposes the necessary class parameters to create a splunk cluster with a master indexer, additional index peers and search heads. This allows the class to be used in ENC tools fairly easily. 

Please review, comment and/or provide any suggestions.

Thanks!

Matt