### PR TITLE
Adds param for ensuring forwarder can be the latest

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -54,7 +54,6 @@ class splunk::forwarder (
   $forwarder_confdir = $splunk::params::forwarder_confdir,
   $forwarder_output  = $splunk::params::forwarder_output,
   $forwarder_input   = $splunk::params::forwarder_input,
-  $forwarder_ensure  = $splunk::params::forwarder_pkg_ensure,
   $create_password   = $splunk::params::create_password,
 ) inherits splunk::params {
 
@@ -76,7 +75,7 @@ class splunk::forwarder (
     }
   }
   package { $package_name:
-    ensure          => $forwarder_ensure,
+    ensure          => $package_ensure,
     provider        => $pkg_provider,
     source          => $pkg_source,
     before          => Service[$virtual_service],

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -44,6 +44,7 @@ class splunk::forwarder (
   $server            = $splunk::params::server,
   $package_source    = $splunk::params::forwarder_pkg_src,
   $package_name      = $splunk::params::forwarder_pkg_name,
+  $package_ensure    = $splunk::params::forwarder_pkg_ensure,
   $logging_port      = $splunk::params::logging_port,
   $splunkd_port      = $splunk::params::splunkd_port,
   $splunkd_listen    = '127.0.0.1',
@@ -74,7 +75,7 @@ class splunk::forwarder (
     }
   }
   package { $package_name:
-    ensure          => installed,
+    ensure          => $splunk::params::forwarder_pkg_ensure,
     provider        => $pkg_provider,
     source          => $pkg_source,
     before          => Service[$virtual_service],

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -54,6 +54,7 @@ class splunk::forwarder (
   $forwarder_confdir = $splunk::params::forwarder_confdir,
   $forwarder_output  = $splunk::params::forwarder_output,
   $forwarder_input   = $splunk::params::forwarder_input,
+  $forwarder_ensure  = $splunk::params::forwarder_pkg_ensure,
   $create_password   = $splunk::params::create_password,
 ) inherits splunk::params {
 
@@ -75,7 +76,7 @@ class splunk::forwarder (
     }
   }
   package { $package_name:
-    ensure          => $splunk::params::forwarder_pkg_ensure,
+    ensure          => $forwarder_ensure,
     provider        => $pkg_provider,
     source          => $pkg_source,
     before          => Service[$virtual_service],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -225,4 +225,5 @@ class splunk::params (
   $forwarder_pkg_src = "${src_root}/${forwarder_src_subdir}/${forwarder_src_pkg}"
   $create_password   = true
 
+  $forwarder_pkg_ensure = 'installed'
 }


### PR DESCRIPTION
There is currently no way to upgrade the forwarder once it has been installed for the first time. I'm using this pull request to open up a line of communication on how we would want to handle upgrading the forwarder or why this currently isn't implemented. 