### PR TITLE
Fix errors for forwarder.pp using rpm package provider

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -62,11 +62,11 @@ class splunk::forwarder (
   $path_delimiter  = $splunk::params::path_delimiter
   if $pkg_provider != undef and $pkg_provider != 'yum' and  $pkg_provider != 'apt' {
     include staging
+    $staged_package  = staging_parse($package_source)
     $pkg_path_parts  = [$staging::path, $staging_subdir, $staged_package]
     $pkg_source      = join($pkg_path_parts, $path_delimiter)
 
     #no need for staging the source if we have yum or apt
-    $staged_package  = staging_parse($package_source)
     staging::file { $staged_package:
       source => $package_source,
       subdir => $staging_subdir,

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -49,7 +49,7 @@ class splunk::forwarder (
   $splunkd_listen    = '127.0.0.1',
   $purge_inputs      = false,
   $purge_outputs     = false,
-  $pkg_provider      = undef,
+  $pkg_provider      = $splunk::params::pkg_provider,
   $forwarder_confdir = $splunk::params::forwarder_confdir,
   $forwarder_output  = $splunk::params::forwarder_output,
   $forwarder_input   = $splunk::params::forwarder_input,


### PR DESCRIPTION
I tried to install splunk::forwarder using the default package provider (rpm), but I ran into errors. This PR resolves those issue for me on a new RH7 machine. 