### PR TITLE
config items are collected with tag - make sure it exists

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -82,6 +82,7 @@ class splunk::forwarder (
     tag             => 'splunk_forwarder',
   }
   # Declare inputs and outputs specific to the forwarder profile
+  $tag_resources = { tag => 'splunk_forwarder' }
   create_resources( 'splunkforwarder_input',$forwarder_input)
   create_resources( 'splunkforwarder_output',$forwarder_output)
   # this is default

--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -83,8 +83,8 @@ class splunk::forwarder (
   }
   # Declare inputs and outputs specific to the forwarder profile
   $tag_resources = { tag => 'splunk_forwarder' }
-  create_resources( 'splunkforwarder_input',$forwarder_input)
-  create_resources( 'splunkforwarder_output',$forwarder_output)
+  create_resources( 'splunkforwarder_input',$forwarder_input, $tag_resources)
+  create_resources( 'splunkforwarder_output',$forwarder_output, $tag_resources)
   # this is default
   ini_setting { 'forwarder_splunkd_port':
     path    => "${splunk::params::forwarder_confdir}/web.conf",


### PR DESCRIPTION
`splunk_forwarder` tag is used for dependency setting (package, service), so it's essential all configuration items created by `splunk::forwarder` class contains those tags (unless user deliberately decides to override them).