### PR TITLE
Actually use the variable somewhere

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,7 @@ class splunk (
   }
 
   package { $package_name:
-    ensure   => installed,
+    ensure   => $package_ensure,
     provider => $pkg_provider,
     source   => $pkg_source,
     before   => Service[$virtual_service],


### PR DESCRIPTION
In #31 I added support for the server ensure variable but I didn't actually use it anywhere this fixes that mistake. Sorry about that.