### PR TITLE
Add splunk_server type and provider

### DIFF
--- a/lib/puppet/provider/splunk_server/ini_setting.rb
+++ b/lib/puppet/provider/splunk_server/ini_setting.rb
@@ -1,0 +1,15 @@
+Puppet::Type.type(:splunk_server).provide(
+  :ini_setting,
+  # set ini_setting as the parent provider
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+  # hard code the file path (this allows purging)
+  def self.file_path
+    case Facter.value(:osfamily)
+    when 'windows'
+      'C:\Program Files\Splunk\etc\system\local\server.conf'
+    else
+      '/opt/splunk/etc/system/local/server.conf'
+    end
+  end
+end

--- a/lib/puppet/type/splunk_server.rb
+++ b/lib/puppet/type/splunk_server.rb
@@ -1,4 +1,4 @@
-Puppet::Type.newtype(:splunk_props) do
+Puppet::Type.newtype(:splunk_server) do
   ensurable
   newparam(:name, :namevar => true) do
     desc 'Setting name to manage from server.conf'

--- a/lib/puppet/type/splunk_server.rb
+++ b/lib/puppet/type/splunk_server.rb
@@ -1,0 +1,24 @@
+Puppet::Type.newtype(:splunk_props) do
+  ensurable
+  newparam(:name, :namevar => true) do
+    desc 'Setting name to manage from server.conf'
+  end
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:setting) do
+    desc 'The setting being defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:section) do
+    desc 'The section the setting is defined under.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+end


### PR DESCRIPTION
This adds a new splunk_server ini_file resource for configuring the Splunk server config.