### PR TITLE
Add conditional logic for using the staging module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,17 +57,22 @@ class splunk (
   include staging
 
   $virtual_service = $splunk::params::server_service
-  $staged_package  = staging_parse($package_source)
   $staging_subdir  = $splunk::params::staging_subdir
 
   $path_delimiter  = $splunk::params::path_delimiter
-  $pkg_path_parts  = [$staging::path, $staging_subdir, $staged_package]
-  $pkg_source      = join($pkg_path_parts, $path_delimiter)
 
-  staging::file { $staged_package:
-    source => $package_source,
-    subdir => $staging_subdir,
-    before => Package[$package_name],
+  if $pkg_provider != undef and $pkg_provider != 'yum' and  $pkg_provider != 'apt' {
+    include staging
+    $pkg_path_parts  = [$staging::path, $staging_subdir, $staged_package]
+    $pkg_source      = join($pkg_path_parts, $path_delimiter)
+
+    #no need for staging the source if we have yum or apt
+    $staged_package  = staging_parse($package_source)
+    staging::file { $staged_package:
+      source => $package_source,
+      subdir => $staging_subdir,
+      before => Package[$package_name],
+    }
   }
 
   package { $package_name:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,6 @@ class splunk (
   $purge_inputs   = false,
   $purge_outputs  = false,
 ) inherits splunk::params {
-  include staging
 
   $virtual_service = $splunk::params::server_service
   $staging_subdir  = $splunk::params::staging_subdir


### PR DESCRIPTION
- If the provider is yum or apt we don't need to use the staging module
  and this logic exists in splunk::forwarder.
- Removes an unnecessary include of the staging module.