### PR TITLE
Various updates and fixes

### DIFF
--- a/lib/puppet/provider/splunkforwarder_web/ini_setting.rb
+++ b/lib/puppet/provider/splunkforwarder_web/ini_setting.rb
@@ -1,0 +1,17 @@
+Puppet::Type.type(:splunkforwarder_web).provide(
+  :ini_setting,
+  # set ini_setting as the parent provider
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+
+  def self.prefetch(resources)
+    catalog = resources[resources.keys.first].catalog
+    splunk_config = catalog.resources.find{|s| s.type == :splunk_config}
+    confdir = splunk_config['forwarder_confdir'] || raise(Puppet::Error, 'Unknown splunk forwarder confdir')
+    @file_path = File.join(confdir, 'web.conf')
+  end
+
+  def self.file_path
+    @file_path
+  end
+end

--- a/lib/puppet/type/splunkforwarder_web.rb
+++ b/lib/puppet/type/splunkforwarder_web.rb
@@ -1,0 +1,24 @@
+Puppet::Type.newtype(:splunkforwarder_web) do
+  ensurable
+  newparam(:name, :namevar => true) do
+    desc 'Setting name to manage from web.conf'
+  end
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:setting) do
+    desc 'The setting being defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+  newproperty(:section) do
+    desc 'The section the setting is defined under.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,8 +51,17 @@ class splunk (
   $pkg_provider   = $splunk::params::pkg_provider,
   $splunkd_listen = '127.0.0.1',
   $web_port       = '8000',
-  $purge_inputs   = false,
-  $purge_outputs  = false,
+  $purge_authentication = false,
+  $purge_authorize      = false,
+  $purge_distsearch     = false,
+  $purge_indexes        = false,
+  $purge_inputs         = false,
+  $purge_limits         = false,
+  $purge_outputs        = false,
+  $purge_props          = false,
+  $purge_server         = false,
+  $purge_transforms     = false,
+  $purge_web            = false,
 ) inherits splunk::params {
 
   $virtual_service = $splunk::params::server_service
@@ -94,30 +103,68 @@ class splunk (
     value   => 'dns',
     tag     => 'splunk_server',
   }
-  ini_setting { 'splunk_server_splunkd_port':
-    path    => "${splunk::params::server_confdir}/web.conf",
+  splunk_web { 'splunk_server_splunkd_port':
     section => 'settings',
     setting => 'mgmtHostPort',
     value   => "${splunkd_listen}:${splunkd_port}",
-    require => Package[$package_name],
-    notify  => Service[$virtual_service],
+    tag => 'splunk_server'
   }
-  ini_setting { 'splunk_server_web_port':
-    path    => "${splunk::params::server_confdir}/web.conf",
+
+  splunk_web { 'splunk_server_web_port':
     section => 'settings',
     setting => 'httpport',
     value   => $web_port,
-    require => Package[$package_name],
-    notify  => Service[$virtual_service],
+    tag => 'splunk_server'
   }
 
   # If the purge parameters have been set, remove all unmanaged entries from
   # the inputs.conf and outputs.conf files, respectively.
-  if $purge_inputs  {
-    resources { 'splunkforwarder_input':  purge => true; }
+  if $purge_authentication  {
+    resources { 'splunk_authentication':  purge => true; }
   }
+
+  if $purge_authorize  {
+    resources { 'splunk_authorize':  purge => true; }
+  }
+
+  if $purge_distsearch  {
+    resources { 'splunk_distsearch':  purge => true; }
+  }
+
+  if $purge_indexes  {
+    resources { 'splunk_indexes':  purge => true; }
+  }
+
+  if $purge_inputs  {
+    resources { 'splunk_input':  purge => true; 
+                'splunkforwarder_input':  purge => true; }
+  }
+
+  if $purge_limits  {
+    resources { 'splunk_limits':  purge => true; }
+  }
+
   if $purge_outputs {
-    resources { 'splunkforwarder_output': purge => true; }
+    resources { 'splunk_output': purge => true;
+                'splunkforwarder_output': purge => true; }
+  }
+
+  if $purge_props  {
+    resources { 'splunk_props':  purge => true; }
+  }
+
+
+  if $purge_server  {
+    resources { 'splunk_server':  purge => true; }
+  }
+
+
+  if $purge_transforms  {
+    resources { 'splunk_transforms':  purge => true; }
+  }
+
+  if $purge_web  {
+    resources { 'splunk_web':  purge => true; }
   }
 
   # This is a module that supports multiple platforms. For some platforms
@@ -163,6 +210,67 @@ class splunk (
   Splunk_output <| tag == 'splunk_server' |> {
     require +> Package[$package_name],
     notify +> Service[$virtual_service],
+  }
+
+  File {
+    owner => $splunk_user,
+    group => $splunk_user,
+    mode => 600,
+  }
+
+  file { "/opt/splunk/etc/system/local/authentication.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/authorize.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/distsearch.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/indexes.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/inputs.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/limits.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/outputs.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/props.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/server.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/transforms.conf":
+    ensure => present,
+    tag => 'splunk_server'
+  }
+
+  file { "/opt/splunk/etc/system/local/web.conf":
+    ensure => present,
+    tag => 'splunk_server'
   }
 
   # Validate: if both Splunk and Splunk Universal Forwarder are installed on

--- a/manifests/platform/posix.pp
+++ b/manifests/platform/posix.pp
@@ -25,13 +25,14 @@ class splunk::platform::posix (
   @exec { 'license_splunkforwarder':
     path    => '/opt/splunkforwarder/bin',
     command => 'splunk start --accept-license --answer-yes',
+    user    => $splunk_user,
     creates => '/opt/splunkforwarder/etc/auth/server.pem',
     timeout => 0,
     tag     => 'splunk_forwarder',
   }
   @exec { 'enable_splunkforwarder':
     path    => '/opt/splunkforwarder/bin',
-    command => 'splunk enable boot-start',
+    command => "splunk enable boot-start -user $splunk_user",
     creates => '/etc/init.d/splunk',
     require => Exec['license_splunkforwarder'],
     tag     => 'splunk_forwarder',
@@ -41,18 +42,18 @@ class splunk::platform::posix (
   @exec { 'license_splunk':
     path    => '/opt/splunk/bin',
     command => 'splunk start --accept-license --answer-yes',
+    user    => $splunk_user,
     creates => '/opt/splunk/etc/auth/splunk.secret',
     timeout => 0,
     tag     => 'splunk_server',
   }
   @exec { 'enable_splunk':
     path    => '/opt/splunk/bin',
-    command => 'splunk enable boot-start',
+    command => "splunk enable boot-start -user $splunk_user",
     creates => '/etc/init.d/splunk',
     require => Exec['license_splunk'],
     tag     => 'splunk_server',
   }
-
 
   # Modify virtual service definitions specific to the Linux platform. These
   # are virtual resources declared in the splunk::virtual class, which we


### PR DESCRIPTION
- Adds the ability to run Splunk as a non-root user on posix systems.
- Adds the splunkforwarder_web type and provider from Nick Perry's fork.
- Adds purging for all the new Splunk types.
- Provisions all the config files to ensure they exist beforehand.
- Properly tags virtual resources.
- Corrects some permission issues.
- Depends on #37 and this will need a rebase once its merged.