### PR TITLE
Add acceptance test skeleton.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,35 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-group :development, :test do
-  gem 'rake',                    :require => false
-  gem 'rspec-puppet',            :require => false
-  gem 'puppetlabs_spec_helper',  :require => false
-  gem 'rspec-system',            :require => false
-  gem 'rspec-system-puppet',     :require => false
-  gem 'rspec-system-serverspec', :require => false
-  gem 'puppet-lint',             :require => false
-  gem 'pry',                     :require => false
+group :test do
+  gem "rake"
+  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "rspec-puppet-facts"
+  gem 'rubocop', '0.33.0'
+  gem 'simplecov', '>= 0.11.0'
+  gem 'simplecov-console'
+
+  gem "puppet-lint-absolute_classname-check"
+  gem "puppet-lint-leading_zero-check"
+  gem "puppet-lint-trailing_comma-check"
+  gem "puppet-lint-version_comparison-check"
+  gem "puppet-lint-classes_and_types_beginning_with_digits-check"
+  gem "puppet-lint-unquoted_string-check"
+  gem 'puppet-lint-resource_reference_syntax'
 end
 
-if facterversion = ENV['FACTER_GEM_VERSION']
-  gem 'facter', facterversion, :require => false
-else
-  gem 'facter', :require => false
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
 end
 
-if puppetversion = ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', puppetversion, :require => false
-else
-  gem 'puppet', :require => false
+group :system_tests do
+  gem "beaker"
+  gem "beaker-rspec"
+  gem "beaker-puppet_install_helper"
 end
-
-# vim:ft=ruby

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class splunk::params (
   $src_root             = 'puppet:///modules/splunk',
   $splunkd_port         = '8089',
   $logging_port         = '9997',
-  $server               = 'splunk'
+  $server               = 'splunk',
   $forwarder_installdir = undef,
   $server_installdir    = undef,
 ) {

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper_acceptance'
+
+describe 'splunk class' do
+  context 'default parameters' do
+    # Using puppet_apply as a helper
+    it 'should work idempotently with no errors' do
+      pp = <<-EOS
+      class { '::splunk': }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+
+    describe package('splunk') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('splunkd') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+end
+
+describe 'splunk class' do
+  context 'default parameters' do
+    # Using puppet_apply as a helper
+    it 'should work idempotently with no errors' do
+      pp = <<-EOS
+      class { '::splunk::forwarder': }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+
+    describe package('splunkforwarder') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('splunkd') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+end

--- a/spec/acceptance/nodesets/centos-511-x64.yml
+++ b/spec/acceptance/nodesets/centos-511-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  centos-511-x64:
+    roles:
+      - master
+    platform: el-5-x86_64
+    box: puppetlabs/centos-5.11-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-5.11-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-66-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box: puppetlabs/centos-6.6-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-7-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/debian-609-x64.yml
+++ b/spec/acceptance/nodesets/debian-609-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  debian-609-x64:
+    roles:
+      - master
+    platform: debian-6-amd64
+    box: puppetlabs/debian-6.0.9-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/debian-6.0.9-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/debian-78-x64.yml
+++ b/spec/acceptance/nodesets/debian-78-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  debian-78-x64:
+    roles:
+      - master
+    platform: debian-7-amd64
+    box: puppetlabs/debian-7.8-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/debian-7.8-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  ubuntu-server-1204-x64:
+    roles:
+      - master
+    platform: ubuntu-1204-amd64
+    box: puppetlabs/ubuntu-12.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-12.04-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/fedora-20-x64.yml
+++ b/spec/acceptance/nodesets/fedora-20-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  fedora-20-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: chef/fedora-20
+    box_url: https://vagrantcloud.com/chef/boxes/fedora-20
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/ubuntu-1204-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1204-x64.yml
@@ -1,0 +1,13 @@
+HOSTS:
+  ubuntu-1204-x64:
+    roles:
+      - master
+    platform: ubuntu-1204-amd64
+    box: puppetlabs/ubuntu-12.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-12.04-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  color: false
+  type: foss

--- a/spec/acceptance/nodesets/ubuntu-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1404-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  ubuntu-1404-x64:
+    roles:
+      - master
+    platform: ubuntu-1404-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/example_spec.rb
+++ b/spec/classes/example_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'splunk' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+
+        context "splunk class without any parameters" do
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_class('splunk::params') }
+          it { is_expected.to contain_class('splunk::install').that_comes_before('splunk::config') }
+          it { is_expected.to contain_class('splunk::config') }
+          it { is_expected.to contain_class('splunk::service').that_subscribes_to('splunk::config') }
+
+          it { is_expected.to contain_service('splunk') }
+          it { is_expected.to contain_package('splunk').with_ensure('present') }
+        end
+      end
+    end
+  end
+
+  context 'unsupported operating system' do
+    describe 'splunk class without any parameters on Solaris/Nexenta' do
+      let(:facts) do
+        {
+          :osfamily        => 'Solaris',
+          :operatingsystem => 'Nexenta',
+        }
+      end
+
+      it { expect { is_expected.to contain_package('splunk') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
+    end
+  end
+end

--- a/spec/fixtures/hiera.yaml
+++ b/spec/fixtures/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: './spec/fixtures/hieradata'
+:hierarchy:
+  - '%{::clientcert}'
+  - 'default'

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -1,0 +1,2 @@
+---
+# Default key/value pairs

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,20 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+
+include RspecPuppetFacts
+
+require 'simplecov'
+require 'simplecov-console'
+
+SimpleCov.start do
+  add_filter '/spec'
+  add_filter '/vendor'
+  formatter SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console
+  ])
+end
+
+RSpec.configure do |c|
+  c.hiera_config = File.expand_path(File.join(__FILE__, '../fixtures/hiera.yaml'))
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,25 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    # Need to stage the Splunk/Splunkforwarder packages here.
+    puppet_module_install(:source => proj_root, :module_name => 'splunk')
+    hosts.each do |host|
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'nanliu-staging'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'puppetlabs-inifile'), { :acceptable_exit_codes => [0,1] }
+    end
+  end
+end


### PR DESCRIPTION
- Adds the acceptance skeleton from the puppet-module-skeleton.
- Adds initial class_spec tests for Splunk and Splunkforwarder classes.
- Includes the appropriate module dependencies for testing.
- This is just the foundation for adding more tests.